### PR TITLE
habitat: Fix building with hab

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -2,5 +2,4 @@ pkg_name=hab-server-go
 pkg_origin=lili
 pkg_scaffolding="core/scaffolding-go"
 pkg_version="0.1.0"
-scaffolding_go_gopath=/source
 pkg_binds=( [db]="port" )


### PR DESCRIPTION
Setting the `scaffolding_go_gopath` variable to `/src/` was a
workaround for some bug in the go scaffolding. The bug is fixed
upstream in the way that setting this variable to some arbitrary value
like it is done now actually breaks the build. So just remove the
assignment - `hab pkg build` works just fine without it.