### PR TITLE
Fix exporting the package to docker

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -3,3 +3,4 @@ pkg_origin=lili
 pkg_scaffolding="core/scaffolding-go"
 pkg_version="0.1.0"
 pkg_binds=( [db]="port" )
+pkg_bin_dirs=(bin)


### PR DESCRIPTION
Apparently, somehow, the lack of this line causes the package to be
not exportable to docker image.